### PR TITLE
fix: harden airline status validation by casting boolean-like fields

### DIFF
--- a/scrape_airline_routes.py
+++ b/scrape_airline_routes.py
@@ -81,10 +81,10 @@ if __name__ == "__main__":
             carriers = []
             for aroute in route["airlineroutes"]:
                 is_passenger = (
-                    aroute["airline"]["is_scheduled_passenger"] == "1"
-                    or aroute["airline"]["is_nonscheduled_passenger"] == "1"
+                    str(aroute["airline"]["is_scheduled_passenger"]) == "1"
+                    or str(aroute["airline"]["is_nonscheduled_passenger"]) == "1"
                 )
-                is_active = aroute["airline"]["active"]
+                is_active = str(aroute["airline"]["active"]) == "1"
                 if is_active and is_passenger:
                     carriers.append(
                         {


### PR DESCRIPTION
Update `is_passenger` and `is_active` flags to handle both string and integer
representations of boolean-like fields (e.g., "1" or 1) by casting to strings
before comparison. 

This ensures the script correctly identifies passenger
carriers and active airlines regardless of the API's response format. The datasource was returning integers instead of strings, causing the `is_passenger` and `is_active` to only return False.

Fixes #9